### PR TITLE
Fix typos

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -5,14 +5,14 @@ title: Frequently Asked Questions
 - When I enter `spark parse some-file`, I get the following error, what does it mean?
     ```
     "some-file" (line ..., column ...):
-    unexpexted end of input
-    expecting Comments
+    unexpected end of input
+    expecting Comment
     ```
     
     The first thing `spark` does when parsing a file, is removing all the comments.
     If your file is so badly formatted that even this goes wrong, you're probably trying to parse the wrong file.
 
-- When I try to use the variable `HOST`, spark cannot resolve it eventhough it is there when I enter `echo $HOST`.
+- When I try to use the variable `HOST`, spark cannot resolve it even though it is there when I enter `echo $HOST`.
   
   This means the variable `HOST` has not been exported.
   Bash does not do this automatically.


### PR DESCRIPTION
Error output changed to match what spark 0.3.2.0 produces.