### PR TITLE
Add Semigroup instance for HashDigest

### DIFF
--- a/src/SuperUserSpark/Diagnose/Types.hs
+++ b/src/SuperUserSpark/Diagnose/Types.hs
@@ -1,10 +1,11 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module SuperUserSpark.Diagnose.Types where
 
-import Import
+import Import hiding ((<>))
 
 import Data.Aeson
 import Data.Hashable
@@ -12,6 +13,10 @@ import Text.Printf
 
 import SuperUserSpark.Bake.Types
 import SuperUserSpark.Compiler.Types
+
+#if __GLASGOW_HASKELL__ < 840
+import Data.Semigroup (Semigroup, (<>))
+#endif
 
 data DiagnoseAssignment = DiagnoseAssignment
     { diagnoseCardReference :: BakeCardReference
@@ -45,9 +50,12 @@ newtype HashDigest =
 
 instance Validity HashDigest
 
+instance Semigroup HashDigest where
+    HashDigest h1 <> HashDigest h2 = HashDigest $ h1 * 31 + h2
+
 instance Monoid HashDigest where
     mempty = HashDigest (hash ())
-    (HashDigest h1) `mappend` (HashDigest h2) = HashDigest $ h1 * 31 + h2
+    mappend = (<>)
 
 instance Hashable HashDigest
 


### PR DESCRIPTION
Semigroup is now a superclass of Monoid. This change is documented here:
https://prime.haskell.org/wiki/Libraries/Proposals/SemigroupMonoid